### PR TITLE
Update INSTRUCTIONS.md

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -7,14 +7,14 @@ In the Integration Toolkit, select **Help > Install New Software**, and enter th
 In the Integration Toolkit, import the Git repositories and set up IIB:
 
 * In the Git Repository Exploring perspective, click **Clone a Git repository**.
-* Clone the Eclipse Paho project by setting the git repository URI to git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.java.git 
+* Clone the Eclipse Paho project by setting the git repository URI to git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.java.git (if you are behind a corporate firewall you might also try using https: instead of git:)
 * Select the master branch.
 * In the Git Repositories view, expand the Tags section, and right-click the v0.1 tagged branch of the Eclipse Paho project to check it out.
 * Import the Eclipse Paho project into your workspace (in the Git Repositories view, under org.eclipse.paho.mqtt.java, right-click Working Directory and select **Import Projects**). 
 * In the Git Repositories view, click the **Clone a Git Repository** icon on the toolbar at the top right of the window.
 * Clone and import the projects:
-  * Set the git repository URI to https//github.com/ot4i/mqtt-client-connector.git
-   (if you are behind a corporate firewall you might also try the git protocol using git://github.com/ot4i/mqtt-client-connector.git)
+  * Set the git repository URI to https://github.com/ot4i/mqtt-client-connector.git (or https:, conversely)
+   
   * Click Next, and select the master branch.
   * Click Next, and set a local destination.
   * Select the option **Import all existing projects after clone finishes**, and click Finish. 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -7,13 +7,13 @@ In the Integration Toolkit, select **Help > Install New Software**, and enter th
 In the Integration Toolkit, import the Git repositories and set up IIB:
 
 * In the Git Repository Exploring perspective, click **Clone a Git repository**.
-* Clone the Eclipse Paho project by setting the git repository URI to git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.java.git (if you are behind a corporate firewall you might also try using https: instead of git:)
+* Clone the Eclipse Paho project by setting the git repository URI to https://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.java.git
 * Select the master branch.
 * In the Git Repositories view, expand the Tags section, and right-click the v0.1 tagged branch of the Eclipse Paho project to check it out.
 * Import the Eclipse Paho project into your workspace (in the Git Repositories view, under org.eclipse.paho.mqtt.java, right-click Working Directory and select **Import Projects**). 
 * In the Git Repositories view, click the **Clone a Git Repository** icon on the toolbar at the top right of the window.
 * Clone and import the projects:
-  * Set the git repository URI to https://github.com/ot4i/mqtt-client-connector.git (or https:, conversely)
+  * Set the git repository URI to https://github.com/ot4i/mqtt-client-connector.git
    
   * Click Next, and select the master branch.
   * Click Next, and set a local destination.


### PR DESCRIPTION
this should be made consistent; use "git:" as default and "https:" only if it doesn't work
